### PR TITLE
ユーザー側：投稿の 公開 / 非公開 設定機能

### DIFF
--- a/app/assets/javascripts/tag-input.js
+++ b/app/assets/javascripts/tag-input.js
@@ -1,6 +1,6 @@
 // ページ更新でtag-it発火
 $(document).ready(function() {
-  $('#new_tweet_tag_list__input').tagit({  // 指定のセレクタに、tag-itを反映
+  $('.tag_form_js').tagit({  // 指定のセレクタに、tag-itを反映
     tagLimit:5,         // タグの最大数
     singleField: true,   // タグの一意性
   });

--- a/app/controllers/user/homes_controller.rb
+++ b/app/controllers/user/homes_controller.rb
@@ -3,8 +3,8 @@
 class User::HomesController < ApplicationController
   def home
     gon.linkpreview_key = ENV['LINK_PREVIEW_API_KEY']
-    # 退会済みユーザーの投稿は除外する
-    active_tweet = Tweet.where(user_id: User.where(is_active: true).ids)
+    # 退会済みユーザーの投稿および非公開設定になっている投稿は除外する
+    active_tweet = Tweet.where(user_id: User.where(is_active: true).ids, is_opened: true)
     @tweets = active_tweet.page(params[:page]).reverse_order
     gon.tweet_id_list = @tweets.ids
   end

--- a/app/controllers/user/tweets_controller.rb
+++ b/app/controllers/user/tweets_controller.rb
@@ -13,8 +13,8 @@ class User::TweetsController < ApplicationController
     new_tweet.user_id = current_user.id
     new_tweet.site_id = site.id
     if new_tweet.save
-      # ホーム画面に戻る
-      redirect_to home_path
+      # マイページに戻る
+      redirect_to user_path(current_user.id)
     else
       render :new
     end
@@ -36,12 +36,11 @@ class User::TweetsController < ApplicationController
   def update
     # サイトを保存する
     tweet = Tweet.find(params[:id])
-    site = tweet.site.id
+    site = tweet.site
     site.update(url: params[:tweet][:url])
-    # タグを保存する
-    # TODO: タグ保存機能の作成
     # 投稿を保存する
-    if tweet.update(site_id: site.id, text: params[:tweet][:text])
+    tweet.site_id = site.id
+    if tweet.update(tweet_params)
       # ホーム画面に戻る
       redirect_to tweet_path(tweet.id)
     else
@@ -61,6 +60,6 @@ class User::TweetsController < ApplicationController
   private
 
   def tweet_params
-    params.require(:tweet).permit(:user_id, :site_id, :text, :tag_list)
+    params.require(:tweet).permit(:user_id, :site_id, :text, :is_opened, :tag_list)
   end
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -8,7 +8,7 @@ class Tweet < ApplicationRecord
   validates :user_id, presence: true
   validates :site_id, presence: true
   validates :text, presence: true
-  validates :is_opened, presence: true
+  validates :is_opened, inclusion: { in: [true, false] }
 
   # association
   belongs_to :user

--- a/app/views/user/shared/_tweet.html.erb
+++ b/app/views/user/shared/_tweet.html.erb
@@ -37,6 +37,8 @@
         <div class='timeline__tweet-text'><%= tweet.text %></div>
         <%# タグ %>
         <%= render 'user/shared/tag_list', tweet: tweet %>
+        <%# 非公開設定時の備考 %>
+        <%= render 'user/shared/tweet_not_opened', tweet: tweet %>
       </div>
     </div>
     <div class='timeline__row3'>

--- a/app/views/user/shared/_tweet_not_opened.html.erb
+++ b/app/views/user/shared/_tweet_not_opened.html.erb
@@ -1,0 +1,5 @@
+<%# 非公開設定の時だけ備考を表示する %>
+<% if tweet.is_opened == false %>
+  <br>
+  <small>非公開 : 他の人からは見えない投稿です</small>
+<% end %>

--- a/app/views/user/tweets/edit.html.erb
+++ b/app/views/user/tweets/edit.html.erb
@@ -15,6 +15,16 @@
         <%= f.text_area :text, id: 'update_tweet_text__input' %>
       </div>
 
+      <div class="field">
+        <%= f.label :tag_list %><br />
+        <%= f.text_field :tag_list, value: @tweet.tag_list.join(","), id: 'update_tweet_tag_list__input', class: 'tag_form_js' %>
+      </div>
+
+      <div class="field">
+        <%= f.label :is_opened %><br />
+        <%= f.check_box :is_opened, id: 'update_tweet_is_opened__input' %>
+      </div>
+
       <div class="actions">
         <%= f.submit "編集する" %>
       </div>
@@ -22,3 +32,6 @@
 
   </div>
 </div>
+
+<%# tag-itを有効にする %>
+<%= javascript_include_tag 'tag-input.js' %>

--- a/app/views/user/tweets/new.html.erb
+++ b/app/views/user/tweets/new.html.erb
@@ -17,13 +17,13 @@
 
       <div class="field">
         <%= f.label :tag_list %><br />
-        <%= f.text_field :tag_list, id: 'new_tweet_tag_list__input' %>
+        <%= f.text_field :tag_list, value: @tweet.tag_list.join(","), id: 'new_tweet_tag_list__input', class: 'tag_form_js' %>
       </div>
 
-      <%# <div class="field"> %>
-        <%# <%= f.label :is_opened %><br /> %>
-        <%#= f.text_field :is_opened, id: 'new_tweet_is_opened__input' %>
-      <%# </div> %>
+      <div class="field">
+        <%= f.label :is_opened %><br />
+        <%= f.check_box :is_opened, id: 'new_tweet_is_opened__input' %>
+      </div>
 
       <div class="actions">
         <%= f.submit "投稿する" %>

--- a/app/views/user/tweets/show.html.erb
+++ b/app/views/user/tweets/show.html.erb
@@ -51,6 +51,8 @@
           <div class='tweet-show__tweet-text'><%= @tweet.text %></div>
           <%# タグ %>
           <%= render 'user/shared/tag_list', tweet: @tweet %>
+          <%# 非公開設定時の備考 %>
+          <%= render 'user/shared/tweet_not_opened', tweet: @tweet %>
         </div>
       </div>
       <div class='tweet-show__row3'>

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Tweet, type: :model do
       site = FactoryBot.create(:site)
       tweet = FactoryBot.build(:tweet, user_id: user.id, site_id: site.id, is_opened: nil)
       tweet.valid?
-      expect(tweet.errors[:is_opened]).to include('を入力してください')
+      expect(tweet.errors[:is_opened]).to include('は一覧にありません')
     end
   end
 end


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
close #92

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
投稿の公開・非公開機能を実装しました。
非公開の場合、マイページ上で投稿した本人のみ閲覧可能です。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
なし