### PR TITLE
[fix] no-image画像の表示処理を修正

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -38,11 +38,7 @@ document.addEventListener("DOMContentLoaded", function () {
           // ページ概要
           // document.getElementById('mydescription_js' + elem).innerHTML = response.description
           // サイト画像
-          if (response.image != "") {
-              document.getElementById('lp_image_js' + elem).src = response.image
-          } else {
-            document.getElementById('lp_image_js' + elem).src = '/no-image.png'
-          }
+          document.getElementById('lp_image_js' + elem).src = response.image
           // ページ URL
           // document.getElementById('myurl_js' + elem).innerHTML = response.url
           // サイトURL

--- a/app/views/user/tweets/_tweet.html.erb
+++ b/app/views/user/tweets/_tweet.html.erb
@@ -16,7 +16,7 @@
         <object>
           <div class='timeline__preview-background'>
             <%= link_to tweet.site.url, target: :_blank, rel: "noopener noreferrer" do %>
-              <img id=<%="lp_image_js" + tweet.id.to_s %> class='timeline__preview'>
+              <img id=<%="lp_image_js" + tweet.id.to_s %> class='timeline__preview' onerror="this.src='<%= asset_path "no-image.png" %>'">
             <% end %>
             <div class='timeline__annotation'>サイトに移動</div>
           </div>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
プレビュー画像がリンク切れの時にno-image画像を表示する処理を修正

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
html側に処理を追加し、リンク切れの場合に代替画像を表示するように指定

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
なし