### PR TITLE
[fix] 管理者側のユーザー編集機能にS3更新タイムラグを加味したバッファを追加

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,6 +18,7 @@ class Admin::UsersController < ApplicationController
   def update
     user = User.find(params[:id])
     if user.update(user_params)
+      sleep(3) # S3への画像反映のタイムラグを考慮して3秒待機
       redirect_to admin_user_path(user.id)
     else
       render :edit


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
管理者側：ユーザー情報編集機能を更新

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
ユーザープロフィール画像をS3に保存し、Lambdaでリサイズして利用するようにしている。
ユーザー情報の編集後にすぐに画面遷移するとまだその処理が終わっておらず、
編集後のプロフィール画像がリンク切れで表示されない。
そのため、編集後に数秒間sleepしてから画面遷移させる。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
ユーザー側のプロフィール編集機能には同様のsleep処理をすでに実装済み